### PR TITLE
Mbo/us/aaicddc 7 poc vm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ production: generate-secrets
 	docker compose exec -T drupal with-contenv bash -lc "drush -l $(SITE) user:role:add fedoraadmin admin"
 	MIGRATE_IMPORT_USER_OPTION=--userid=1 $(MAKE) hydrate
 	docker compose exec -T drupal with-contenv bash -lc 'drush -l $(SITE) migrate:import --userid=1 islandora_fits_tags'
+	docker compose exec -T drupal with-contenv bash -lc 'drush islandora:settings:set-trusted-host-patterns "^$(DOMAIN)$\"'	
 	$(MAKE) node_access_rebuild
 	$(MAKE) login
 

--- a/local-prod.env
+++ b/local-prod.env
@@ -1,0 +1,199 @@
+# Environment variables defined in this file apply to both the Makefile and to
+# docker-compose.yml
+# 
+# Due to restrictions in the `env-file` format we cannot specify multi-line
+# values for environment variables. For this reason the environment
+# variables are set on service definitions in the docker-compose.*.yml files,
+# rather than defined in `env-file` files.
+
+# Determines which docker-compose file(s) will be used for the `drupal` service.
+# See documentation for more details.
+ENVIRONMENT=custom
+
+# Enable this to generate a docker-compose file that uses secrets.
+# If you're running staging, CI, or production, set to true.
+USE_SECRETS=true
+
+###############################################################################
+# Environment variables specific to composer.
+###############################################################################
+
+COMPOSE_HTTP_TIMEOUT=480
+
+# Also used for naming services in traefik as well as defining network alias and urls.
+# For example the `drupal` service will be found at `islandora.${COMPOSE_PROJECT_NAME}.${DRUPAL_SITE_HOST}`.
+# See https://docs.docker.com/compose/reference/envvars/
+COMPOSE_PROJECT_NAME=darwin-isle-dc
+
+# Allows building custom image with buildkit.
+COMPOSE_DOCKER_CLI_BUILD=1
+DOCKER_BUILDKIT=1
+
+# Dockerfile to use when building the custom project.
+PROJECT_DRUPAL_DOCKERFILE=Dockerfile
+
+# Custom namespace for your created Drupal images (eg. your dockerhub username)
+# preface this with a URL to use a container registry like Github or Gitlab
+# Used in the image name when running `make build` and `make push-image`
+CUSTOM_IMAGE_NAMESPACE=rwaai
+
+# Image name of custom drupal image
+# This is used when pulling a custom image for environments set to custom and 
+# when building a custom image with make build
+CUSTOM_IMAGE_NAME=darwin-islandora
+
+# Tag for custom image
+# This is used when pulling a custom image for environments set to custom and
+# when building a custom image with make build
+CUSTOM_IMAGE_TAG=latest
+
+# Packagist repo to use when creating a site with make starter
+# Change this if you want to build from a different codebase than the starter site
+CODEBASE_PACKAGE=islandora/islandora-starter-site:dev-main
+
+# Includes `traefik` as a service, if false assume we are sharing a traefik
+# from another project.
+INCLUDE_TRAEFIK_SERVICE=true
+TRAEFIK_LOG_LEVEL=ERROR
+
+# Should we use ACME to generate a SSL Certificate
+USE_ACME=false
+# Specify email to tie SSL Certificate to with ACME provider
+ACME_EMAIL=your-email@example.com
+# KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'.
+ACME_KEY_TYPE=RSA4096
+
+# ACME Defaults for Let's Encrypt Service
+# ACME_SERVER=https://acme-v02.api.letsencrypt.org/directory
+# Default duration for the certificate is 90 days or 2,160 hours for Let's Encrypt
+# ACME_CERT_DURATION=2160
+# ACME_EAB_KID=
+# ACME_EAB_HMAC=
+
+# Includes `watchtower` as a service.
+INCLUDE_WATCHTOWER_SERVICE=false
+
+# Includes `etcd` as a service.
+INCLUDE_ETCD_SERVICE=false
+
+# Includes `code-server` as a service.
+INCLUDE_CODE_SERVER_SERVICE=false
+
+# Choose which database backend to use: mariadb/postgresql
+# Services that only support MySQL (Matomo) do not have the option to change.
+# Also at this time not all Drupal modules work with PostgresSQL, it is provided
+# as option here so it can be tested and fixed at some later date.
+DRUPAL_DATABASE_SERVICE=mariadb
+FCREPO_DATABASE_SERVICE=mariadb
+
+# Repository to use for pulling isle-buildkit images, change to `local`
+# To use images you have built locally with isle-buildkit, or use your 
+# custom docker registry if you have set up one.
+#
+REPOSITORY=islandora
+
+# The version of the isle-buildkit images, non isle-buildkit images have
+# their versions specified explicitly in their respective docker-compose files.
+TAG=1.0.10
+
+###############################################################################
+# Exposed Containers & Ports
+###############################################################################
+
+# Expose Cantaloupe at ${DOMAIN}/cantaloupe
+EXPOSE_CANTALOUPE=true
+
+# Expose Matomo at ${DOMAIN}/matomo
+EXPOSE_MATOMO=true
+
+# Expose Drupal at ${DOMAIN}
+EXPOSE_DRUPAL=true
+
+# Expose MySQL over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_MYSQL=false
+MYSQL_PORT=3306
+
+# Expose Postgres over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_POSTGRES=false
+POSTGRES_PORT=5432
+
+# Expose the Traefik dashboard over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_TRAEFIK_DASHBOARD=false
+TRAEFIK_DASHBOARD_PORT=8080
+
+# Expose Fedora over the given port - Necessary for Canteloupe
+EXPOSE_FEDORA=true
+FEDORA_PORT=8081
+
+# Expose Blazegraph over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_BLAZEGRAPH=false
+BLAZEGRAPH_PORT=8082
+
+# Expose Activemq over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_ACTIVEMQ=false
+ACTIVEMQ_PORT=8161
+
+# Expose SOLR over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_SOLR=false
+SOLR_PORT=8983
+
+# Expose Code Server over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_CODE_SERVER=false
+CODE_SERVER_PORT=8443
+
+###############################################################################
+# Global Environment variables
+###############################################################################
+
+DOMAIN=prod-islandora.traefik.me
+SITE=https://${DOMAIN}
+DISABLE_SYN=false
+FEDORA_6=true
+RESTART_POLICY=unless-stopped
+
+# PHP variables
+PHP_MEMORY_LIMIT=256M
+PHP_POST_MAX_SIZE=128M
+PHP_UPLOAD_MAX_FILESIZE=128M
+PHP_MAX_EXECUTION_TIME=30
+
+# If you're just demoing or are starting from scratch, use this.
+INSTALL_EXISTING_CONFIG=false
+DRUPAL_INSTALL_PROFILE=standard
+
+# If you're installing from an existing codebase, uncomment this
+#INSTALL_EXISTING_CONFIG=true
+#DRUPAL_INSTALL_PROFILE=minimal
+
+# If you're experiencing timeouts in Alpaca, consider bumping these
+# values for each connector.  They are in milliseconds (1000 = 1 second).
+ALPACA_OCR_TIMEOUT=300000
+ALPACA_FITS_TIMEOUT=300000
+ALPACA_HOUDINI_TIMEOUT=300000
+ALPACA_HOMARUS_TIMEOUT=300000
+
+# Set Memory Limit for each container.
+ACTIVEMQ_MEMORY_LIMIT=2G
+ALPACA_MEMORY_LIMIT=2G
+BLAZEGRAPH_MEMORY_LIMIT=5G
+CANTALOUPE_MEMORY_LIMIT=5G
+CRAYFITS_MEMORY_LIMIT=1G
+DRUPAL_MEMORY_LIMIT=5G
+FCREPO_MEMORY_LIMIT=5G
+FITS_MEMORY_LIMIT=5G
+HOMARUS_MEMORY_LIMIT=1G
+HOUDINI_MEMORY_LIMIT=1G
+HYPERCUBE_MEMORY_LIMIT=512M
+IDE_MEMORY_LIMIT=5G
+MARIADB_MEMORY_LIMIT=1G
+MATOMO_MEMORY_LIMIT=1G
+MILLINER_MEMORY_LIMIT=1G
+RECAST_MEMORY_LIMIT=1G
+SOLR_MEMORY_LIMIT=8G
+TRAEFIK_MEMORY_LIMIT=8G
+WATCHTOWER_MEMORY_LIMIT=2G
+
+# Configuration to enable the custom delegate script for Cantaloupe
+CANTALOUPE_DELEGATE_SCRIPT_ENABLED=false
+CANTALOUPE_DELEGATE_SCRIPT_PATHNAME=/opt/tomcat/bin/delegates.rb
+CANTALOUPE_HTTPSOURCE_LOOKUP_STRATEGY=BasicLookupStrategy

--- a/poc.env
+++ b/poc.env
@@ -145,7 +145,7 @@ CODE_SERVER_PORT=8443
 # Global Environment variables
 ###############################################################################
 
-DOMAIN=preprod-islandora.traefik.me
+DOMAIN=study-repository-dev.darwin-eu.org
 SITE=https://${DOMAIN}
 DISABLE_SYN=false
 FEDORA_6=true


### PR DESCRIPTION
- Rename preprod.env file to local-prod.env, and change domain to `prod-islandora.traefik.me` (this will be used to test production builds locally)
- Create new poc.env file for the POC VM environment with domain `study-repository-dev.darwin-eu.org`
- Update the make file so when doing `make production` it also updates the Islandora settings.php file to include the Trusted Host setting (set to the current domain). This resolves the security error in the reports status page
- TODO: TLS certificate (Let's Encrypt), to be addressed in next sprint