### PR TITLE
Fix build error, module is not installed after import

### DIFF
--- a/codebase/config/sync/core.extension.yml
+++ b/codebase/config/sync/core.extension.yml
@@ -136,6 +136,7 @@ module:
   views_nested_details: 0
   views_node_access_filter: 0
   views_ui: 0
+  workbench_email: 0
   workflows: 0
   content_translation: 10
   views: 10


### PR DESCRIPTION
- need to commit `core.extension.yml` when adding modules, as well as the composer.json and composer.lock files
- if this is not done you get errors when building 

```
li class="messages__item">Configuration <em class="placeholder">workbench_email.workbench_email_template.published_to_review</em> depends on the <em class="placeholder">Workbench email</em> module that will not be installed after import.</li>
```